### PR TITLE
P3860R1: Address LWG feedback

### DIFF
--- a/atomic.md
+++ b/atomic.md
@@ -14,6 +14,10 @@ toc: true
 # Revision History
 ## R1
 - Added `noexcept` specifier.
+- Changed constraints wording to say "`T` and `U` are similar types" per LWG feedback
+- Added converting constructor to specializations for integral types
+- Added converting constructor to specializations for floating-point types
+- Added converting constructor to specializations for pointer types
 
 ## R0
 - Initial revision
@@ -49,13 +53,40 @@ constexpr atomic_ref(const atomic_ref<U>& ref) noexcept;
 
 [9]{.pnum} *Contraints*:
 
-- [9.1]{.pnum} `is_same_v<remove_cv_t<T>, remove_cv_t<U>>` is `true`, and
+- [9.1]{.pnum} `T` and `U` are similar types ([conv.qual]), and
 
 - [9.2]{.pnum} `is_convertible_v<U*, T*>` is `true`
 
 [10]{.pnum} *Postconditions*: `*this` references the object referenced by `ref`.
 
 :::
+
+Change [atomics.ref.int]{.sref} as follows:
+
+```cpp
+    constexpr explicit atomic_ref(integral-type&);
+    constexpr atomic_ref(const atomic_ref&) noexcept;
+    @[`template <class U>`]{.add}@
+    @[`constexpr atomic_ref(const atomic_ref<U>&) noexcept;`]{.add}@
+```
+
+Change [atomics.ref.float]{.sref} as follows:
+
+```cpp
+    constexpr explicit atomic_ref(floating-point-type&);
+    constexpr atomic_ref(const atomic_ref&) noexcept;
+    @[`template <class U>`]{.add}@
+    @[`constexpr atomic_ref(const atomic_ref<U>&) noexcept;`]{.add}@
+```
+
+Change [atomics.ref.pointer]{.sref} as follows:
+
+```cpp
+    constexpr explicit atomic_ref(pointer-type&);
+    constexpr atomic_ref(const atomic_ref&) noexcept;
+    @[`template <class U>`]{.add}@
+    @[`constexpr atomic_ref(const atomic_ref<U>&) noexcept;`]{.add}@
+```
 
 # Implementation Experience
 


### PR DESCRIPTION
Addressing https://github.com/cplusplus/nbballot/issues/884#issuecomment-3487907524

**Warning:** I did not build locally; I got what I expect is an unrelated error.
```
Traceback (most recent call last):
  File "/Users/qdi/Projects/huixie90_cpp_papers/wg21/data/filters/wg21.py", line 577, in <module>
    pf.run_filters([
    ~~~~~~~~~~~~~~^^
        divspan,
        ^^^^^^^^
    ...<5 lines>...
        automatic_header_link,
        ^^^^^^^^^^^^^^^^^^^^^^
    ], prepare, finalize)
    ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/qdi/Projects/huixie90_cpp_papers/wg21/deps/python/lib/python3.13/site-packages/panflute/io.py", line 201, in run_filters
    prepare(doc)
    ~~~~~~~^^^^^
  File "/Users/qdi/Projects/huixie90_cpp_papers/wg21/data/filters/wg21.py", line 41, in prepare
    number = re.match("[PD]([0-9]+)R[0-9]+", document.upper())
                                             ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'upper'
Error running filter /Users/qdi/Projects/huixie90_cpp_papers/wg21/data/filters/wg21.py:
Filter returned error status 1
make: *** [generated/concat.lwg.feedback.20230906.pdf] Error 83
```